### PR TITLE
Issue #7

### DIFF
--- a/man/SDForest.Rd
+++ b/man/SDForest.Rd
@@ -30,7 +30,8 @@ SDForest(
   nTree_env = NULL,
   max_candidates = 100,
   Q_scale = TRUE,
-  verbose = TRUE
+  verbose = TRUE,
+  predictors = NULL
 )
 }
 \arguments{
@@ -114,6 +115,10 @@ Default is \code{TRUE} to not reduce the signal of high variance covariates,
 and we do not know of a scenario where this hurts.}
 
 \item{verbose}{If \code{TRUE} fitting information is shown.}
+
+\item{predictors}{Subset of colnames(X) or numerical indices of the covariates 
+for which an effect on y should be estimated. All the other covariates are only
+used for deconfounding.}
 }
 \value{
 Object of class \code{SDForest} containing:
@@ -168,6 +173,11 @@ X <- matrix(rnorm(n * 5), nrow = n)
 y <- sign(X[, 1]) * 3 + rnorm(n)
 model <- SDForest(x = X, y = y, Q_type = 'no_deconfounding', nTree = 5, cp = 0.5)
 predict(model, newdata = data.frame(X))
+
+###### subset of predictors
+# if we know, that only the first covariate has an effect on y,
+# we can estimate only its effect and use the others just for deconfounding
+model <- SDForest(x = X, y = y, cp = 0.5, nTree = 5, predictors = c(1))
 
 \donttest{
 set.seed(42)

--- a/man/SDTree.Rd
+++ b/man/SDTree.Rd
@@ -23,7 +23,8 @@ SDTree(
   gpu = FALSE,
   mem_size = 1e+07,
   max_candidates = 100,
-  Q_scale = TRUE
+  Q_scale = TRUE,
+  predictors = NULL
 )
 }
 \arguments{
@@ -87,6 +88,10 @@ proposed at each node for each covariate.}
 \item{Q_scale}{Should data be scaled to estimate the spectral transformation? 
 Default is \code{TRUE} to not reduce the signal of high variance covariates, 
 and we do not know of a scenario where this hurts.}
+
+\item{predictors}{Subset of colnames(X) or numerical indices of the covariates 
+for which an effect on y should be estimated. All the other covariates are only
+used for deconfounding.}
 }
 \value{
 Object of class \code{SDTree} containing
@@ -129,6 +134,11 @@ n <- 10
 X <- matrix(rnorm(n * 5), nrow = n)
 y <- sign(X[, 1]) * 3 + rnorm(n)
 model <- SDTree(x = X, y = y, cp = 0.5)
+
+###### subset of predictors
+# if we know, that only the first covariate has an effect on y,
+# we can estimate only its effect and use the others just for deconfounding
+model <- SDTree(x = X, y = y, cp = 0.5, predictors = c(1))
 
 \donttest{
 set.seed(42)

--- a/tests/testthat/test-PredictorSelection.R
+++ b/tests/testthat/test-PredictorSelection.R
@@ -23,5 +23,17 @@ for(selection in selection_list){
   tree2 <- SDTree(x = X_sel, y = Y, cp = 0, 
                   Q_type = "no_deconfounding")
   
-  expect_equal(tree1$var_importance, tree2$var_importance)
+  expect_equal(tree1[c(1, 3, 4)], tree2[c(1, 3, 4)])
+  
+  # Forest
+  set.seed(1)
+  forest1 <- SDForest(x = X, y = Y, predictors = selection, 
+                      Q_type = "no_deconfounding", nTree = 2)
+  set.seed(1)
+  forest2 <- SDForest(x = X_sel, y = Y, 
+                      Q_type = "no_deconfounding", nTree = 2)
+  
+  expect_equal(forest1[c(1, 3:11)], forest2[c(1, 3:11)])
+  expect_equal(predict(forest1, data.frame(X_sel)), predict(forest2, data.frame(X_sel)))
+  expect_equal(predict(forest1, data.frame(X)), predict(forest2, data.frame(X)))
 }

--- a/tests/testthat/test-PredictorSelection.R
+++ b/tests/testthat/test-PredictorSelection.R
@@ -1,0 +1,27 @@
+set.seed(1)
+
+X <- matrix(rnorm(50 * 20), nrow = 50)
+Y <- sign(X[, 1]) + rnorm(50)
+
+colnames(X) <- LETTERS[1:20]
+
+selection_list <- list(c(1, 4), 20, "A", c("D", "E"))
+selection <- "A"
+
+for(selection in selection_list){
+  tree1 <- SDTree(x = X, y = Y, cp = 0, predictors = selection, 
+                  Q_type = "no_deconfounding")
+
+  X_sel <- matrix(X[, selection], ncol = length(selection))
+  
+  if(is.numeric(selection)){
+    colnames(X_sel) <- colnames(X)[selection]
+  }else{
+    colnames(X_sel) <- selection
+  }
+  
+  tree2 <- SDTree(x = X_sel, y = Y, cp = 0, 
+                  Q_type = "no_deconfounding")
+  
+  expect_equal(tree1$var_importance, tree2$var_importance)
+}


### PR DESCRIPTION
Add the option to select some variables as predictors in SDTree and SDForest. This gives the option to use some covariates only for the deconfounding part. If one knows what covariates might be relevant to predict y, one can decrease the difficulty of the variable selection part. This closes Issue #7 